### PR TITLE
examples: point examples to upbound/function-kro:v0.0.1

### DIFF
--- a/example/extensions.yaml
+++ b/example/extensions.yaml
@@ -11,7 +11,7 @@ kind: Function
 metadata:
   name: function-kro
 spec:
-  package: xpkg.upbound.io/jaredorg/function-kro:v0.0.24
+  package: xpkg.upbound.io/upbound/function-kro:v0.0.1
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig


### PR DESCRIPTION
This PR simply bumps the extensions manifest in the examples folder to use the main upbound/function-kro instead of my own personal fork.  Let's start with a v0.0.1 (which I'll kick off using the CI pipeline) to start our testing! 🎉 