### PR TITLE
bump examples to v0.0.2

### DIFF
--- a/example/extensions.yaml
+++ b/example/extensions.yaml
@@ -11,7 +11,7 @@ kind: Function
 metadata:
   name: function-kro
 spec:
-  package: xpkg.upbound.io/upbound/function-kro:v0.0.1
+  package: xpkg.upbound.io/upbound/function-kro:v0.0.2
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig


### PR DESCRIPTION
### Description of your changes

This PR just bumps the version in the examples file to use `xpkg.upbound.io/upbound/function-kro:v0.0.2`

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
