### PR TITLE
docs: make basic example subnet availability zones variable

### DIFF
--- a/example/basic/composition.yaml
+++ b/example/basic/composition.yaml
@@ -41,7 +41,7 @@ spec:
           spec:
             forProvider:
               region: ${schema.spec.region}
-              availabilityZone: us-west-2a
+              availabilityZone: ${schema.spec.region + "a"}
               cidrBlock: 192.168.0.0/18
               vpcId: ${vpc.status.atProvider.id}
       - id: subnetAZB
@@ -52,7 +52,7 @@ spec:
           spec:
             forProvider:
               region: ${schema.spec.region}
-              availabilityZone: us-west-2b
+              availabilityZone: ${schema.spec.region + "b"}
               cidrBlock: 192.168.64.0/18
               vpcId: ${vpc.status.atProvider.id}
       - id: subnetAZC
@@ -63,7 +63,7 @@ spec:
           spec:
             forProvider:
               region: ${schema.spec.region}
-              availabilityZone: us-west-2c
+              availabilityZone: ${schema.spec.region + "c"}
               cidrBlock: 192.168.128.0/18
               vpcId: ${vpc.status.atProvider.id}
       - id: securityGroup


### PR DESCRIPTION
### Description of your changes

This PR makes a small fix to the basic example composition to make the availability zones of subnets variable (based on region specified on XR) as opposed to the hard coded zone they have now.

This example has been tested with a different region and all worked OK:
```
apiVersion: example.crossplane.io/v1
kind: NetworkingStack
metadata:
  name: cool-network
spec:
  region: eu-west-3
```

```
❯ crossplane beta trace -w networkingstack.example.crossplane.io/cool-network
NAME                                                   SYNCED   READY   STATUS
NetworkingStack/cool-network (default)                 True     True    Available
├─ SecurityGroup/cool-network-8daaa8afcfdc (default)   True     True    Available
├─ Subnet/cool-network-04547f722022 (default)          True     True    Available
├─ Subnet/cool-network-915a37833ae4 (default)          True     True    Available
├─ Subnet/cool-network-b83e75b45812 (default)          True     True    Available
└─ VPC/cool-network-7f17bba9d177 (default)             True     True    Available
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
