### PR TITLE
docs: include NOTICE file from upstream KRO

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,43 @@
+This product includes code adapted from KRO (Kubernetes Resource Orchestrator),
+originally developed under https://github.com/kubernetes-sigs/kro
+
+The adapted code is located in the kro/ directory. All modifications are
+documented in files under the patches/ directory.
+
+The NOTICE file from https://github.com/kubernetes-sigs/kro/blob/main/NOTICE is
+included in its entirety below.
+
+--- Original NOTICE from KRO ---
+
+When donating the KRO project to the CNCF, not all contributors were reached
+to sign the CNCF CLA prior to donation. As such, according to the CNCF rules to donate a repository,
+we must add a NOTICE referencing section 7 of the CLA with a list of developers who could not be reached.
+
+`7. Should You wish to submit work that is not Your original creation, You may
+submit it to the Foundation separately from any Contribution, identifying the
+complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which you are personally aware, and conspicuously marking the
+work as "Submitted on behalf of a third-party: [named here]".`
+
+Submitted on behalf of a third-party: @amirahav
+Submitted on behalf of a third-party: @AnushkaaBansal
+Submitted on behalf of a third-party: @AshwinSriram11
+Submitted on behalf of a third-party: @candonov
+Submitted on behalf of a third-party: @chkp-dvirpa
+Submitted on behalf of a third-party: @feliperubo
+Submitted on behalf of a third-party: @HeeManSu7
+Submitted on behalf of a third-party: @iamahgoub
+Submitted on behalf of a third-party: @jknutson
+Submitted on behalf of a third-party: @johnknutsonhc
+Submitted on behalf of a third-party: @khalilj
+Submitted on behalf of a third-party: @markoskandylis
+Submitted on behalf of a third-party: @meetreks
+Submitted on behalf of a third-party: @petar-cvit
+Submitted on behalf of a third-party: @premdass
+Submitted on behalf of a third-party: @roin-orca
+Submitted on behalf of a third-party: @Rudra-Sankha-Sinhamahapatra
+Submitted on behalf of a third-party: @ryan-atkins
+Submitted on behalf of a third-party: @TiberiuGC
+Submitted on behalf of a third-party: @vibe
+Submitted on behalf of a third-party: @vmanikes


### PR DESCRIPTION
### Description of your changes

This PR simply adds the upstream KRO NOTICE file to this repo, along with a pre-amble to provide more context.

This is additive to the already existing license file, original copyright/license headers, modifications list, and multiple attributions in the main README.

The NOTICE file was missed and this PR aims to rectify that oversight 🙇 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
