### PR TITLE
docs: include new omit and collections limits examples in README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ See the [`example/`](example/) directory for complete working examples:
 | [readiness](example/readiness/) | Custom readiness conditions with `readyWhen` |
 | [externalref](example/externalref/) | Referencing existing cluster resources outside of the XR/composition |
 | [collections](example/collections/) | Dynamic resource expansion with `forEach` |
+| [omit](example/omit/) | Conditional field removal using the `omit()` CEL function |
+| [collection-limits](example/collection-limits/) | Enforcing maximum collection size limits |
 
 See the [examples README](example/README.md) for setup instructions and walkthroughs.
 


### PR DESCRIPTION
### Description of your changes

This PR simply adds index links to the new omit and collections limits examples in the main README, for easier discoverability.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
