### PR TITLE
build: add github workflows for backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,28 @@
+name: Backport
+
+on:
+  pull_request_target:
+    types: [closed]
+  # See also commands.yml for the /backport triggered variant of this workflow.
+
+permissions:
+  contents: read
+
+jobs:
+  open-pr:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-24.04
+    if: github.event.pull_request.merged
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Open Backport PR
+        uses: korthout/backport-action@4aaf0e03a94ff0a619c9a511b61aeb42adea5b02 # v4.2.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_workspace: ${{ github.workspace }}

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -1,0 +1,38 @@
+name: Comment Commands
+
+on: issue_comment
+
+permissions:
+  contents: read
+
+jobs:
+  # See also backport.yml, which is the variant that triggers on PR merge rather
+  # than on comment.
+  backport:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-24.04
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/backport')
+    steps:
+    - name: Extract Command
+      id: command
+      uses: xt0rted/slash-command-action@bf51f8f5f4ea3d58abc7eca58f77104182b23e88 # v2
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        command: backport
+        reaction: "true"
+        reaction-type: "eyes"
+        allow-edits: "false"
+        permission-level: write
+
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        fetch-depth: 0
+
+    - name: Open Backport PR
+      uses: korthout/backport-action@4aaf0e03a94ff0a619c9a511b61aeb42adea5b02 # v4.2.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_workspace: ${{ github.workspace }}


### PR DESCRIPTION
### Description of your changes

This PR adds github workflows for automatically performing backports. They are copied from the Crossplane repo, so no new logic here.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
