### PR TITLE
chore: bump examples to use v0.2.0

### DIFF
--- a/example/extensions.yaml
+++ b/example/extensions.yaml
@@ -11,7 +11,7 @@ kind: Function
 metadata:
   name: function-kro
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/function-kro:v0.1.0
+  package: xpkg.crossplane.io/crossplane-contrib/function-kro:v0.2.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig


### PR DESCRIPTION
### Description of your changes

This PR bumps the examples to use the new v0.2.0 release: https://github.com/crossplane-contrib/function-kro/releases/tag/v0.2.0

I've tested this change with the `/test-examples` skill and everything passed ✅ 

We should consider doing a `latest` or `alpha` tag or something so we don't have to keep updating this...

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
