### PR TITLE
refactor(fn): factor RunFunction into focused helpers

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -54,9 +54,7 @@ func NewFunction(log logging.Logger, rgdConfig graph.RGDConfig) *Function {
 }
 
 // RunFunction runs the Function.
-func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) { //nolint:gocognit // See below.
-	// This loop is fairly complex, but more readable with less abstraction.
-
+func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
 	f.log.Debug("Running function", "tag", req.GetMeta().GetTag(), "advertisesCapabilities", request.AdvertisesCapabilities(req), "capabilities", req.GetMeta().GetCapabilities())
 	rsp := response.To(req, response.DefaultTTL)
 
@@ -75,23 +73,11 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	}
 
 	// Collect all GVKs we need schemas for, which is the XR and all resource templates.
-	gvks := make([]schema.GroupVersionKind, 0, len(rg.Resources)+1)
 	xrGVK := schema.FromAPIVersionAndKind(oxr.Resource.GetAPIVersion(), oxr.Resource.GetKind())
-	gvks = append(gvks, xrGVK)
-	for _, r := range rg.Resources {
-		if r.ExternalRef != nil {
-			// this is an external ref, we have access to the GVK directly
-			gvks = append(gvks, schema.FromAPIVersionAndKind(r.ExternalRef.APIVersion, r.ExternalRef.Kind))
-			continue
-		}
-
-		// it's a template, unmarshal it into an unstructured so we can access the GVK from that
-		u := &unstructured.Unstructured{}
-		if err := k8sjson.Unmarshal(r.Template.Raw, u); err != nil {
-			response.Fatal(rsp, errors.Wrapf(err, "cannot unmarshal resource id %q", r.ID))
-			return rsp, nil
-		}
-		gvks = append(gvks, schema.FromAPIVersionAndKind(u.GetAPIVersion(), u.GetKind()))
+	gvks, err := collectGVKs(xrGVK, rg.Resources)
+	if err != nil {
+		response.Fatal(rsp, err)
+		return rsp, nil
 	}
 
 	// Request the schemas we need in the function response so Crossplane will
@@ -197,77 +183,9 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	}
 
 	// Process all runtime nodes in topological order, generating the entire set of desired composed resources.
-	for _, node := range rt.Nodes() {
-		id := node.Spec.Meta.ID
-
-		// External refs are read-only and not managed by this function or Crossplane.
-		// Skip them from desired output.
-		if node.Spec.Meta.Type == graph.NodeTypeExternal || node.Spec.Meta.Type == graph.NodeTypeExternalCollection {
-			f.log.Debug("Not including external ref in desired resources", "id", id)
-			continue
-		}
-
-		// Check if this node should be ignored (includeWhen evaluated to false).
-		ignored, err := node.IsIgnored()
-		if err != nil {
-			f.log.Info("Error checking if resource is ignored", "id", id, "err", err)
-			continue
-		}
-		if ignored {
-			f.log.Debug("Not including ignored resource in desired resources", "id", id)
-			continue
-		}
-
-		// Get the desired state with CEL expressions resolved.
-		// This is critical for SSA - desired state must only contain fields
-		// we want to own, not provider-defaulted fields from observed state.
-		desired, err := node.GetDesired()
-		if err != nil {
-			if runtime.IsDataPending(err) {
-				f.log.Debug("Not including resource with pending data in desired resources", "id", id)
-				continue
-			}
-			response.Fatal(rsp, errors.Wrapf(err, "cannot get desired state for resource %q", id))
-			return rsp, nil
-		}
-
-		// For single resources, desired has one element.
-		// For collections, desired has multiple elements (one per forEach expansion).
-		isCollection := node.Spec.Meta.Type == graph.NodeTypeCollection
-		for _, r := range desired {
-			resourceName := id
-			if isCollection {
-				// This resource is part of a collection: append the resource's metadata.name
-				// to produce a stable composed resource name that doesn't depend on list order.
-				resourceName = id + "-" + r.GetName()
-			}
-
-			cd, err := composed.From(r)
-			if err != nil {
-				response.Fatal(rsp, errors.Wrapf(err, "cannot create composed resource from template id %s", id))
-				return rsp, nil
-			}
-
-			// add the resource to the desired composed resources and set its
-			// ready state. If readyWhen expressions are defined, we explicitly
-			// set ReadyTrue/ReadyFalse based on their evaluation. If no
-			// readyWhen is defined, we leave readiness as ReadyUnspecified so
-			// that later functions in the pipeline (like function-auto-ready)
-			// can determine readiness using their own logic.
-			readyState := resource.ReadyUnspecified
-			if len(node.Spec.ReadyWhen) > 0 {
-				readyState = resource.ReadyFalse
-				if err := node.CheckReadiness(); err != nil {
-					if !stderrors.Is(err, runtime.ErrWaitingForReadiness) {
-						f.log.Info("Error checking resource readiness", "id", id, "err", err)
-					}
-				} else {
-					readyState = resource.ReadyTrue
-				}
-			}
-			f.log.Debug("Resource ready state", "id", id, "ready", readyState)
-			dcds[resource.Name(resourceName)] = &resource.DesiredComposed{Resource: cd, Ready: readyState}
-		}
+	if err := buildDesiredComposed(f.log, rt, dcds); err != nil {
+		response.Fatal(rsp, err)
+		return rsp, nil
 	}
 
 	if err := response.SetDesiredComposedResources(rsp, dcds); err != nil {
@@ -277,34 +195,11 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 
 	// Build a minimal desired XR containing only the status paths declared in
 	// the ResourceGraph. This is critical for SSA - we must only include fields
-	// we want to own. The runtime uses soft resolution for instance status,
-	// returning only fields where all CEL expressions were successfully resolved.
-	dxr := &composite.Unstructured{Unstructured: unstructured.Unstructured{Object: map[string]any{}}}
-	dxr.SetAPIVersion(oxr.Resource.GetAPIVersion())
-	dxr.SetKind(oxr.Resource.GetKind())
-
-	// Get the resolved status fields from the instance node (KRO runtime node corresponding to the XR).
-	instanceDesired, err := rt.Instance().GetDesired()
+	// we want to own.
+	dxr, err := buildDesiredXRStatus(rt, g, oxr)
 	if err != nil {
-		response.Fatal(rsp, errors.Wrap(err, "cannot get desired instance status"))
+		response.Fatal(rsp, err)
 		return rsp, nil
-	}
-
-	// Copy resolved status fields to the desired XR.
-	if len(instanceDesired) > 0 && instanceDesired[0] != nil {
-		src := fieldpath.Pave(instanceDesired[0].Object)
-		dst := fieldpath.Pave(dxr.Object)
-		for _, v := range g.Instance.Variables {
-			val, err := src.GetValue(v.Path)
-			if err != nil {
-				// Value not resolved yet (CEL dependency not satisfied), skip it.
-				continue
-			}
-			if err := dst.SetValue(v.Path, val); err != nil {
-				response.Fatal(rsp, errors.Wrapf(err, "cannot set desired XR status field %q", v.Path))
-				return rsp, nil
-			}
-		}
 	}
 
 	if err := response.SetDesiredCompositeResource(rsp, &resource.Composite{Resource: dxr}); err != nil {
@@ -313,6 +208,25 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	}
 
 	return rsp, nil
+}
+
+// collectGVKs returns the GVKs for the XR and every resource in the graph.
+func collectGVKs(xrGVK schema.GroupVersionKind, resources []*v1beta1.Resource) ([]schema.GroupVersionKind, error) {
+	gvks := make([]schema.GroupVersionKind, 0, len(resources)+1)
+	gvks = append(gvks, xrGVK)
+	for _, r := range resources {
+		if r.ExternalRef != nil {
+			gvks = append(gvks, schema.FromAPIVersionAndKind(r.ExternalRef.APIVersion, r.ExternalRef.Kind))
+			continue
+		}
+
+		u := &unstructured.Unstructured{}
+		if err := k8sjson.Unmarshal(r.Template.Raw, u); err != nil {
+			return nil, errors.Wrapf(err, "cannot unmarshal resource id %q", r.ID)
+		}
+		gvks = append(gvks, schema.FromAPIVersionAndKind(u.GetAPIVersion(), u.GetKind()))
+	}
+	return gvks, nil
 }
 
 func requireSchemas(req *fnv1.RunFunctionRequest, rsp *fnv1.RunFunctionResponse, gvks []schema.GroupVersionKind) {
@@ -650,6 +564,115 @@ func findCollectionNodeID(id string, nodesByID map[string]*runtime.Node) string 
 		}
 		remaining = prefix
 	}
+}
+
+// buildDesiredComposed processes all runtime nodes in topological order,
+// building the desired composed resources map. Collection resources are named
+// "{id}-{metadata.name}" for stable identity across reconciles.
+func buildDesiredComposed(log logging.Logger, rt *runtime.Runtime, dcds map[resource.Name]*resource.DesiredComposed) error { //nolint:gocognit // Readability is better with the logic inline.
+	for _, node := range rt.Nodes() {
+		id := node.Spec.Meta.ID
+
+		// External refs are read-only and not managed by this function or Crossplane.
+		// Skip them from desired output.
+		if node.Spec.Meta.Type == graph.NodeTypeExternal || node.Spec.Meta.Type == graph.NodeTypeExternalCollection {
+			log.Debug("Not including external ref in desired resources", "id", id)
+			continue
+		}
+
+		// Check if this node should be ignored (includeWhen evaluated to false).
+		ignored, err := node.IsIgnored()
+		if err != nil {
+			log.Info("Error checking if resource is ignored", "id", id, "err", err)
+			continue
+		}
+		if ignored {
+			log.Debug("Not including ignored resource in desired resources", "id", id)
+			continue
+		}
+
+		// Get the desired state with CEL expressions resolved.
+		// This is critical for SSA - desired state must only contain fields
+		// we want to own, not provider-defaulted fields from observed state.
+		desired, err := node.GetDesired()
+		if err != nil {
+			if runtime.IsDataPending(err) {
+				log.Debug("Not including resource with pending data in desired resources", "id", id)
+				continue
+			}
+			return errors.Wrapf(err, "cannot get desired state for resource %q", id)
+		}
+
+		// For single resources, desired has one element.
+		// For collections, desired has multiple elements (one per forEach expansion).
+		isCollection := node.Spec.Meta.Type == graph.NodeTypeCollection
+		for _, r := range desired {
+			resourceName := id
+			if isCollection {
+				// This resource is part of a collection: append the resource's metadata.name
+				// to produce a stable composed resource name that doesn't depend on list order.
+				resourceName = id + "-" + r.GetName()
+			}
+
+			cd, err := composed.From(r)
+			if err != nil {
+				return errors.Wrapf(err, "cannot create composed resource from template id %s", id)
+			}
+
+			// add the resource to the desired composed resources and set its
+			// ready state. If readyWhen expressions are defined, we explicitly
+			// set ReadyTrue/ReadyFalse based on their evaluation. If no
+			// readyWhen is defined, we leave readiness as ReadyUnspecified so
+			// that later functions in the pipeline (like function-auto-ready)
+			// can determine readiness using their own logic.
+			readyState := resource.ReadyUnspecified
+			if len(node.Spec.ReadyWhen) > 0 {
+				readyState = resource.ReadyFalse
+				if err := node.CheckReadiness(); err != nil {
+					if !stderrors.Is(err, runtime.ErrWaitingForReadiness) {
+						log.Info("Error checking resource readiness", "id", id, "err", err)
+					}
+				} else {
+					readyState = resource.ReadyTrue
+				}
+			}
+			log.Debug("Resource ready state", "id", id, "ready", readyState)
+			dcds[resource.Name(resourceName)] = &resource.DesiredComposed{Resource: cd, Ready: readyState}
+		}
+	}
+
+	return nil
+}
+
+// buildDesiredXRStatus builds a minimal desired XR containing only the resolved
+// status paths declared in the ResourceGraph. This is critical for SSA - we
+// must only include fields we want to own.
+func buildDesiredXRStatus(rt *runtime.Runtime, g *graph.Graph, oxr *resource.Composite) (*composite.Unstructured, error) {
+	dxr := &composite.Unstructured{Unstructured: unstructured.Unstructured{Object: map[string]any{}}}
+	dxr.SetAPIVersion(oxr.Resource.GetAPIVersion())
+	dxr.SetKind(oxr.Resource.GetKind())
+
+	instanceDesired, err := rt.Instance().GetDesired()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot get desired instance status")
+	}
+
+	if len(instanceDesired) > 0 && instanceDesired[0] != nil {
+		src := fieldpath.Pave(instanceDesired[0].Object)
+		dst := fieldpath.Pave(dxr.Object)
+		for _, v := range g.Instance.Variables {
+			val, err := src.GetValue(v.Path)
+			if err != nil {
+				// Value not resolved yet (CEL dependency not satisfied), skip it.
+				continue
+			}
+			if err := dst.SetValue(v.Path, val); err != nil {
+				return nil, errors.Wrapf(err, "cannot set desired XR status field %q", v.Path)
+			}
+		}
+	}
+
+	return dxr, nil
 }
 
 // structToSpecSchema converts a protobuf Struct (as returned by Crossplane's

--- a/fn.go
+++ b/fn.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	stderrors "errors"
-	"fmt"
 	"maps"
 	"strings"
 
@@ -43,6 +42,15 @@ type Function struct {
 
 	log       logging.Logger
 	rgdConfig graph.RGDConfig
+}
+
+// NewFunction returns a Function with the supplied configuration. A nil logger
+// defaults to a no-op logger.
+func NewFunction(log logging.Logger, rgdConfig graph.RGDConfig) *Function {
+	if log == nil {
+		log = logging.NewNopLogger()
+	}
+	return &Function{log: log, rgdConfig: rgdConfig}
 }
 
 // RunFunction runs the Function.
@@ -89,7 +97,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	// Request the schemas we need in the function response so Crossplane will
 	// send them to us as part of the next request. Do this on every function
 	// run so our requirements are stable.
-	f.requireSchemas(req, rsp, gvks)
+	requireSchemas(req, rsp, gvks)
 
 	// Build the schema resolver from the schemas that Crossplane has provided to us.
 	resolver, xrSchema, err := f.buildResolver(req, gvks, xrGVK)
@@ -174,7 +182,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	}
 
 	// Group observed composed resources by their runtime node ID.
-	observedByNodeID := f.groupObservedByNodeID(ocds, nodesByID)
+	observedByNodeID := groupObservedByNodeID(f.log, ocds, nodesByID)
 
 	// Set observed state on each node so the KRO runtime has access to all its
 	// observed fields/values to use when evaluating expressions.
@@ -307,7 +315,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	return rsp, nil
 }
 
-func (f *Function) requireSchemas(req *fnv1.RunFunctionRequest, rsp *fnv1.RunFunctionResponse, gvks []schema.GroupVersionKind) {
+func requireSchemas(req *fnv1.RunFunctionRequest, rsp *fnv1.RunFunctionResponse, gvks []schema.GroupVersionKind) {
 	// If Crossplane supports required_schemas (v2.2+), use those exclusively.
 	if request.HasCapability(req, fnv1.Capability_CAPABILITY_REQUIRED_SCHEMAS) {
 		for _, gvk := range gvks {
@@ -488,7 +496,7 @@ func (f *Function) externalRefSelectorsFromRuntime(rt *runtime.Runtime, xrNamesp
 
 		if node.Spec.Meta.Type == graph.NodeTypeExternalCollection {
 			// attempt to build selectors for this external collection
-			selector, err := f.externalCollectionSelector(node)
+			selector, err := externalCollectionSelector(node)
 			if err != nil {
 				if runtime.IsDataPending(err) {
 					f.log.Debug("External collection not resolvable yet, skipping", "id", node.Spec.Meta.ID)
@@ -543,7 +551,7 @@ func (f *Function) externalRefSelectorsFromRuntime(rt *runtime.Runtime, xrNamesp
 
 // externalCollectionSelector resolves an external collection node's template and
 // extracts the label selector to build a Crossplane ResourceSelector with MatchLabels.
-func (f *Function) externalCollectionSelector(node *runtime.Node) (*fnv1.ResourceSelector, error) {
+func externalCollectionSelector(node *runtime.Node) (*fnv1.ResourceSelector, error) {
 	// compute/resolve all the expressions in this external collection's template
 	desired, err := node.GetDesired()
 	if err != nil {
@@ -597,7 +605,7 @@ func (f *Function) externalCollectionSelector(node *runtime.Node) (*fnv1.Resourc
 // For collections, the composed resource name uses the pattern
 // "collectionNodeID-metadataName" (e.g., "subnets-my-app-us-east-1") and has
 // the kro.run/collection-index label set.
-func (f *Function) groupObservedByNodeID(ocds map[resource.Name]resource.ObservedComposed, nodesByID map[string]*runtime.Node) map[string][]*unstructured.Unstructured {
+func groupObservedByNodeID(log logging.Logger, ocds map[resource.Name]resource.ObservedComposed, nodesByID map[string]*runtime.Node) map[string][]*unstructured.Unstructured {
 	observedByNodeID := make(map[string][]*unstructured.Unstructured)
 	for name, r := range ocds {
 		id := string(name) // ID is the same as the composed resource name
@@ -616,7 +624,7 @@ func (f *Function) groupObservedByNodeID(ocds map[resource.Name]resource.Observe
 		}
 		// This resource doesn't match any node - might be from a different function
 		// or a stale resource. Skip it.
-		f.log.Debug("Observed resource has no matching node", "name", name)
+		log.Debug("Observed resource has no matching node", "name", name)
 	}
 
 	return observedByNodeID
@@ -644,23 +652,23 @@ func findCollectionNodeID(id string, nodesByID map[string]*runtime.Node) string 
 	}
 }
 
-// StructToSpecSchema converts a protobuf Struct (as returned by Crossplane's
+// structToSpecSchema converts a protobuf Struct (as returned by Crossplane's
 // required_schemas) to a kube-openapi spec.Schema.
 func structToSpecSchema(s *structpb.Struct) (*spec.Schema, error) {
 	if s == nil {
-		return nil, fmt.Errorf("schema struct is nil")
+		return nil, errors.New("schema struct is nil")
 	}
 
 	// Convert protobuf Struct to JSON bytes
 	jsonBytes, err := protojson.Marshal(s)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal struct to JSON: %w", err)
+		return nil, errors.Wrap(err, "cannot marshal struct to JSON")
 	}
 
 	// Unmarshal JSON into spec.Schema
 	schema := &spec.Schema{}
 	if err := json.Unmarshal(jsonBytes, schema); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal JSON to spec.Schema: %w", err)
+		return nil, errors.Wrap(err, "cannot unmarshal JSON to spec.Schema")
 	}
 
 	return schema, nil

--- a/fn_test.go
+++ b/fn_test.go
@@ -1597,9 +1597,9 @@ func TestRunFunction(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			f := NewFunction(logging.NewNopLogger(), graph.RGDConfig{
-					MaxCollectionSize:          1000,
-					MaxCollectionDimensionSize: 10,
-				})
+				MaxCollectionSize:          1000,
+				MaxCollectionDimensionSize: 10,
+			})
 			rsp, err := f.RunFunction(tc.args.ctx, tc.args.req)
 
 			if diff := cmp.Diff(tc.want.rsp, rsp, protocmp.Transform()); diff != "" {

--- a/fn_test.go
+++ b/fn_test.go
@@ -1596,13 +1596,10 @@ func TestRunFunction(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			f := &Function{
-				log: logging.NewNopLogger(),
-				rgdConfig: graph.RGDConfig{
+			f := NewFunction(logging.NewNopLogger(), graph.RGDConfig{
 					MaxCollectionSize:          1000,
 					MaxCollectionDimensionSize: 10,
-				},
-			}
+				})
 			rsp, err := f.RunFunction(tc.args.ctx, tc.args.req)
 
 			if diff := cmp.Diff(tc.want.rsp, rsp, protocmp.Transform()); diff != "" {
@@ -1617,13 +1614,10 @@ func TestRunFunction(t *testing.T) {
 }
 
 func TestRunFunctionCollectionSizeLimitExceeded(t *testing.T) {
-	f := &Function{
-		log: logging.NewNopLogger(),
-		rgdConfig: graph.RGDConfig{
-			MaxCollectionSize:          2,
-			MaxCollectionDimensionSize: 10,
-		},
-	}
+	f := NewFunction(logging.NewNopLogger(), graph.RGDConfig{
+		MaxCollectionSize:          2,
+		MaxCollectionDimensionSize: 10,
+	})
 
 	rsp, err := f.RunFunction(context.Background(), &fnv1.RunFunctionRequest{
 		Meta: &fnv1.RequestMeta{Tag: "test", Capabilities: []fnv1.Capability{fnv1.Capability_CAPABILITY_CAPABILITIES, fnv1.Capability_CAPABILITY_REQUIRED_SCHEMAS}},
@@ -1706,13 +1700,10 @@ func TestRunFunctionOmitRemovesField(t *testing.T) {
 		_ = features.FeatureGate.Set("CELOmitFunction=false")
 	})
 
-	f := &Function{
-		log: logging.NewNopLogger(),
-		rgdConfig: graph.RGDConfig{
-			MaxCollectionSize:          1000,
-			MaxCollectionDimensionSize: 10,
-		},
-	}
+	f := NewFunction(logging.NewNopLogger(), graph.RGDConfig{
+		MaxCollectionSize:          1000,
+		MaxCollectionDimensionSize: 10,
+	})
 
 	rsp, err := f.RunFunction(context.Background(), &fnv1.RunFunctionRequest{
 		Meta: &fnv1.RequestMeta{Tag: "test", Capabilities: []fnv1.Capability{fnv1.Capability_CAPABILITY_CAPABILITIES, fnv1.Capability_CAPABILITY_REQUIRED_SCHEMAS}},

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func (c *CLI) Run() error {
 		MaxCollectionDimensionSize: c.RGDMaxCollectionDimSize,
 	}
 
-	return function.Serve(&Function{log: log, rgdConfig: rgdConfig},
+	return function.Serve(NewFunction(log, rgdConfig),
 		function.Listen(c.Network, c.Address),
 		function.MTLSCertificates(c.TLSCertsDir),
 		function.Insecure(c.Insecure),


### PR DESCRIPTION
### Description of your changes

This PR is an attempt to clean up the `fn.go` part of the code base a bit, as a result of running some of @negz golang related skills.

The main `RunFunction` mixed orchestration with inline implementations, making the processing flow hard to follow and preventing independent testing of self-contained operations.

This PR restructures the code we own (fn.go, fn_test.go, main.go) without changing any behavior:

- Add a `NewFunction` constructor that defaults nil loggers to no-op,  preventing nil-pointer panics in tests
- Convert stateless methods to package-level functions (`requireSchemas`, `externalCollectionSelector`,  `groupObservedByNodeID`)
- Extract `collectGVKs`, `buildDesiredComposed`, and `buildDesiredXRStatus` so `RunFunction` reads as a linear sequence of helper calls and error handling
- Order helpers in the file to match the call sequence in `RunFunction`
- Align error wrapping in `structToSpecSchema` with the rest of the file (`errors.Wrap` / `"cannot X"` instead of `fmt.Errorf` / `"failed to X"`)

`RunFunction` no longer needs a gocognit suppression.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute