### PR TITLE
ci: add check-diff job and harden workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
         description: Package version (e.g. v0.1.0)
         required: false
 
+permissions:
+  contents: read
+
 env:
   # Common versions
   GO_VERSION: '1.25.7'
@@ -49,13 +52,37 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false  # The golangci-lint action does its own caching.
 
-      - name: Check go mod tidy
-        run: go mod tidy && git diff --exit-code go.mod go.sum
-
       - name: Lint
         uses: golangci/golangci-lint-action@v9
         with:
           version: ${{ env.GOLANGCI_VERSION }}
+
+  check-diff:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Check go mod tidy
+        run: go mod tidy && git diff --exit-code go.mod go.sum
+
+      - name: Generate
+        run: go generate ./...
+
+      - name: Check Diff
+        run: |
+          DIFF=$(git diff --stat)
+          if [ -n "$DIFF" ]; then
+            echo "::error::Generated files are not up to date. Please run 'go generate ./...' and commit the result."
+            echo ""
+            git diff
+            exit 1
+          fi
 
   unit-test:
     runs-on: ubuntu-24.04
@@ -131,6 +158,9 @@ jobs:
   # pushes them as a multi-platform package. We only push the package it the
   # XPKG_ACCESS_ID and XPKG_TOKEN secrets were provided.
   push:
+    permissions:
+      contents: read
+      packages: write # for pushing to ghcr.io
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-24.04
     needs:


### PR DESCRIPTION
### Description of your changes

The CI workflow didn't verify that generated files (CRD manifests, deepcopy, OpenAPI schemas) were up to date. A contributor could change `input/v1beta1/` types without re-running `go generate`, and CI would pass. The workflow also used GitHub's default token permissions, which are broader than necessary.

This PR adds a `check-diff` job that runs `go mod tidy` and `go generate ./...`, then fails if the working tree is dirty. The existing `go mod tidy` check is moved from the `lint` job into `check-diff` where it's a better fit.

It also restricts the workflow's default `GITHUB_TOKEN` to `contents: read` via a top-level `permissions` block, with an explicit `packages: write` override on the `push` job that needs it for GHCR. This follows the pattern from crossplane/crossplane#7131.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute