### PR TITLE
Return fatal error when schema resolution gets empty response

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -303,9 +303,9 @@ func (f *Function) buildResolverFromSchemas(req *fnv1.RunFunctionRequest, gvks [
 		schemas[gvk] = specSchema
 	}
 
-	// There are no schemas we care about yet
+	// Crossplane responded with required schemas, but we have no usable schemas from the response.
 	if len(schemas) == 0 {
-		return nil, nil, nil
+		return nil, nil, errors.New("no usable schemas found in response")
 	}
 
 	// Create the schema map resolver
@@ -367,9 +367,9 @@ func (f *Function) buildResolverFromCRDs(req *fnv1.RunFunctionRequest, gvks []sc
 		crds = append(crds, crd)
 	}
 
+	// Crossplane responded to our request for CRDs, but we have no usable CRDS from the response.
 	if len(crds) == 0 {
-		// No CRDs available yet.
-		return nil, nil, nil
+		return nil, nil, errors.New("no usable CRDs found in response")
 	}
 
 	// Create combined resolver from CRDs.

--- a/fn_test.go
+++ b/fn_test.go
@@ -316,6 +316,143 @@ func TestRunFunction(t *testing.T) {
 				},
 			},
 		},
+		"EmptySchemasFromRequiredSchemas": {
+			reason: "When Crossplane responds via required_schemas but all schemas are nil, the function should return a fatal error rather than silently returning empty desired state",
+			args: args{
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "test", Capabilities: []fnv1.Capability{fnv1.Capability_CAPABILITY_CAPABILITIES, fnv1.Capability_CAPABILITY_REQUIRED_SCHEMAS}},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "kro.fn.crossplane.io/v1alpha1",
+						"kind": "ResourceGraph",
+						"resources": [{
+							"id": "bucket",
+							"template": {
+								"apiVersion": "s3.aws.upbound.io/v1beta1",
+								"kind": "Bucket",
+								"metadata": {},
+								"spec": {
+									"forProvider": {
+										"region": "us-west-2"
+									}
+								}
+							}
+						}],
+						"status": {
+							"bucketName": "${bucket.status.atProvider.id}"
+						}
+					}`),
+					Observed: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{
+								"apiVersion": "example.crossplane.io/v1",
+								"kind": "XBucket",
+								"metadata": {"name": "test-bucket"},
+								"spec": {}
+							}`),
+						},
+					},
+					// Crossplane responded with schema entries but all are nil,
+					// simulating a problem causing all schemas to not be found.
+					RequiredSchemas: map[string]*fnv1.Schema{
+						"example.crossplane.io/v1, Kind=XBucket": nil,
+						"s3.aws.upbound.io/v1beta1, Kind=Bucket": nil,
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta: &fnv1.ResponseMeta{Tag: "test", Ttl: durationpb.New(response.DefaultTTL)},
+					Requirements: &fnv1.Requirements{
+						Schemas: map[string]*fnv1.SchemaSelector{
+							"example.crossplane.io/v1, Kind=XBucket": {
+								ApiVersion: "example.crossplane.io/v1",
+								Kind:       "XBucket",
+							},
+							"s3.aws.upbound.io/v1beta1, Kind=Bucket": {
+								ApiVersion: "s3.aws.upbound.io/v1beta1",
+								Kind:       "Bucket",
+							},
+						},
+					},
+					Results: []*fnv1.Result{{
+						// we should be returning a fatal result, we don't have usable schemas and we can't compose desired resources
+						Severity: fnv1.Severity_SEVERITY_FATAL,
+						Message:  "cannot process schemas: no usable schemas found in response",
+						Target:   fnv1.Target_TARGET_COMPOSITE.Enum(),
+					}},
+				},
+			},
+		},
+		"EmptyCRDsFromRequiredResources": {
+			reason: "When Crossplane responds via required_resources but all CRD entries are empty, the function should return a fatal error rather than silently returning empty desired state",
+			args: args{
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "test", Capabilities: []fnv1.Capability{}},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "kro.fn.crossplane.io/v1alpha1",
+						"kind": "ResourceGraph",
+						"resources": [{
+							"id": "bucket",
+							"template": {
+								"apiVersion": "s3.aws.upbound.io/v1beta1",
+								"kind": "Bucket",
+								"metadata": {},
+								"spec": {
+									"forProvider": {
+										"region": "us-west-2"
+									}
+								}
+							}
+						}],
+						"status": {
+							"bucketName": "${bucket.status.atProvider.id}"
+						}
+					}`),
+					Observed: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{
+								"apiVersion": "example.crossplane.io/v1",
+								"kind": "XBucket",
+								"metadata": {"name": "test-bucket"},
+								"spec": {}
+							}`),
+						},
+					},
+					// Crossplane responded for all GVKs but with empty items,
+					// simulating CRDs that couldn't be found.
+					RequiredResources: map[string]*fnv1.Resources{
+						"example.crossplane.io/v1, Kind=XBucket": {Items: []*fnv1.Resource{}},
+						"s3.aws.upbound.io/v1beta1, Kind=Bucket": {Items: []*fnv1.Resource{}},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta: &fnv1.ResponseMeta{Tag: "test", Ttl: durationpb.New(response.DefaultTTL)},
+					Requirements: &fnv1.Requirements{
+						Resources: map[string]*fnv1.ResourceSelector{
+							"example.crossplane.io/v1, Kind=XBucket": {
+								ApiVersion: "apiextensions.k8s.io/v1",
+								Kind:       "CustomResourceDefinition",
+								Match:      &fnv1.ResourceSelector_MatchName{MatchName: "xbuckets.example.crossplane.io"},
+							},
+							"s3.aws.upbound.io/v1beta1, Kind=Bucket": {
+								ApiVersion: "apiextensions.k8s.io/v1",
+								Kind:       "CustomResourceDefinition",
+								Match:      &fnv1.ResourceSelector_MatchName{MatchName: "buckets.s3.aws.upbound.io"},
+							},
+						},
+					},
+					Results: []*fnv1.Result{{
+						// we should return a fatal result because we have no CRD schemas to use
+						// and cannot compose desired resources without them
+						Severity: fnv1.Severity_SEVERITY_FATAL,
+						Message:  "cannot process schemas: no usable CRDs found in response",
+						Target:   fnv1.Target_TARGET_COMPOSITE.Enum(),
+					}},
+				},
+			},
+		},
 		"DesiredXROnlyContainsDeclaredStatus": {
 			reason: "The desired XR should contain resolved status expressions but not observed XR metadata (uid, resourceVersion) or existing status (conditions)",
 			args: args{


### PR DESCRIPTION
### Description of your changes

Fixes #45

When Crossplane responded to our schema/CRD requirements but none of the responses contained usable data, the function treated this the same as "still waiting" — it silently returned an early response with no desired composed resources. If the requirements loop stabilized with this response, Crossplane could garbage collect existing composed resources.

`buildResolverFromSchemas` and `buildResolverFromCRDs` both have early guards for "Crossplane hasn't responded yet" (empty response map), but the downstream "no usable schemas found" check also returned nil — making the two states indistinguishable. Since the early guards already handle the "waiting" case, reaching the downstream check means Crossplane did respond but had nothing useful. That's a fatal error, not a reason to wait.

Note that partial failures (some schemas found, others missing) were already safe — the KRO graph builder fails when it encounters a nil schema, which propagates as a fatal response. This change addresses the total failure case where *all* schemas come back empty.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute