### PR TITLE
docs: fixes 'readyWhen' default behaviour description

### DIFF
--- a/package/input/kro.fn.crossplane.io_resourcegraphs.yaml
+++ b/package/input/kro.fn.crossplane.io_resourcegraphs.yaml
@@ -179,7 +179,8 @@ spec:
                   description: |-
                     ReadyWhen is a list of CEL expressions that determine when this resource is considered ready.
                     All expressions must evaluate to true for the resource to be ready.
-                    If not specified, the resource is considered ready when it exists.
+                    If not specified, readiness is left as ReadyUnspecified so that later functions in the pipeline
+                    (like function-auto-ready) can determine readiness using their own logic.
                     Examples:
                     - Single resource: ["database.status.phase == 'Running'", "database.status.readyReplicas > 0"]
                     - Collection: ["each.status.phase == 'Running'"]


### PR DESCRIPTION
### Description of your changes

The default behavior of docs of the `readyWhen` field did not match the actual behavior. I suppose, because this changed but the docs didn't. I took the new description from `fn.go` and adapted the language to fit into the docs style (passive voice).

~Fixes #~

I have:

- [x] Read and followed Crossplane's [contribution process].
- ~[ ] Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
