### PR TITLE
ci: pin GitHub Action digests and enable semantic commits in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    ":semanticCommits"
   ],
   "crossplane": {
     "managerFilePatterns": [


### PR DESCRIPTION
### Description of your changes

This PR hardens our Renovate config by adding two presets to `extends`:

- `helpers:pinGitHubActionDigests` - pins GitHub Actions to commit SHAs instead of mutable tags like `@v6`, so a compromised or re-pointed tag can't silently ship new code into our workflows. Renovate keeps the SHAs (and their `# vX` comments) updated, and will open a follow-up PR to pin the actions still tag-pinned in `ci.yml` (`backport.yml` and `commands.yml` are already SHA-pinned).
- `:semanticCommits` - forces conventional-commit prefixes on Renovate's PRs instead of relying on auto-detection against our mixed commit history.

This brings our `extends` in line with crossplane core's [`renovate-base.json5`](https://github.com/crossplane/crossplane/blob/main/.github/renovate-base.json5#L3-L7), which extends exactly these three presets.

Renovate docs: [`helpers:pinGitHubActionDigests`](https://docs.renovatebot.com/presets-helpers/), [`:semanticCommits`](https://docs.renovatebot.com/presets-default/).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit tests for my change.~ (Renovate config only; nothing testable.)

[contribution process]: https://git.io/fj2m9
