### PR TITLE
chore: add claude codes worktree path to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ go.work
 # Claude Code - ignore user-specific files, commit shared skills/commands
 /.claude/settings.local.json
 /.claude/memory/
+/.claude/worktrees/
 /docs/plans/
 
 # Demo files


### PR DESCRIPTION
### Description of your changes

Similar to other claude code files that we gitignore, `/.claude/worktrees` is now added to the list.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
