### PR TITLE
docs: clarify the package-health check in the test-examples skill

### DIFF
--- a/.claude/skills/test-examples/SKILL.md
+++ b/.claude/skills/test-examples/SKILL.md
@@ -32,7 +32,7 @@ Do NOT delete or recreate an existing cluster. This is a safety guardrail — th
 **If no cluster exists**, proceed with setup. Read the `## Pre-Requisites` section of `example/README.md` and execute every step — cluster creation, Crossplane install, extensions, and AWS credential configuration. The README is the source of truth for setup; do not hardcode those steps here.
 
 After setup completes, verify the full stack is working:
-- All packages are installed and healthy (`kubectl get pkg` — all should show `INSTALLED=True` and `HEALTHY=True`)
+- All packages are installed and healthy. Packages take a few minutes to pull, so poll `kubectl get pkg` until every row shows `INSTALLED=True` and `HEALTHY=True`. Note it prints separate Function and Provider tables, each with its own header row, so don't parse columns with awk/cut; reuse the `grep -q True && ! grep -q False` approach from Phase 3.2.
 - ProviderConfig exists and is ready
 
 If any setup step fails, **STOP** and report the failure with full output. Do not attempt examples with a broken setup.


### PR DESCRIPTION
### Description of your changes

The Phase 1 setup check in the `test-examples` skill told the runner to verify packages with a one-shot `kubectl get pkg` showing `INSTALLED=True` / `HEALTHY=True`, but never said packages take a few minutes to pull or how to wait for them.

That gap invited ad-hoc awk-based poll loops that never converge: `kubectl get pkg` prints separate Function and Provider tables, each with its own header row, so column counting against a single header never matches.

This clarifies that the check needs polling, and routes to the same `grep True/False` approach the skill already documents for trace parsing in Phase 3.2. Docs-only change to the skill under `.claude/`; no behavior change to the examples.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Added or updated unit tests for my change.~~ Docs-only change to a skill file; no unit tests apply.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
