### PR TITLE
docs(example/externalRef): mention how to match cluster-scoped resources

### DIFF
--- a/example/externalref/README.md
+++ b/example/externalref/README.md
@@ -34,3 +34,6 @@ carries the region, environment, and CIDR from the single ConfigMap, and
 computed across all subscriber ConfigMaps. The VPC renders with configuration
 sourced from the ConfigMap; the subnet and security group depend on the VPC's ID
 and reconcile on a cluster.
+
+To reference cluster-scoped resources, use label-selector.
+If `metadata.name` is set, kro will default to the instance namespace.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

We are  trying out function-kro, and really liked the examples in this repo to get started! :)

We stumbled into an issue with referencing cluster-scoped resources in `externalRef`.
The [kro-documentation](https://kro.run/0.7.0/docs/concepts/rgd/resource-definitions/external-references#how-externalref-works) mentions that you can reference cluster-scoped resources by just omitting namespace, but it doesnt specify that this only works for the external collection reference (label selector).

This fact is a bit hidden in the [code](https://github.com/kubernetes-sigs/kro/pull/1180/changes): 

Maybe this could be useful to contribute to the upstream docs as well, but thought it's nice to start with a small note here.


What do you think? 

I have:

- [x] Read and followed Crossplane's [contribution process].
~- [ ] Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
