### PR TITLE
fix(fn): use correct English plural for CRD name in schema fallback

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"strings"
 
+	"github.com/gobuffalo/flect"
 	"github.com/kubernetes-sigs/kro/api/v1alpha1"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -295,7 +296,7 @@ func requireSchemas(req *fnv1.RunFunctionRequest, rsp *fnv1.RunFunctionResponse,
 			ApiVersion: "apiextensions.k8s.io/v1",
 			Kind:       "CustomResourceDefinition",
 			Match: &fnv1.ResourceSelector_MatchName{
-				MatchName: strings.ToLower(gvk.Kind + "s." + gvk.Group),
+				MatchName: strings.ToLower(flect.Pluralize(gvk.Kind) + "." + gvk.Group),
 			},
 		}
 	}

--- a/fn_test.go
+++ b/fn_test.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 
@@ -2353,6 +2354,73 @@ func TestDecodeAsK8sAPI(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want, tc.in); diff != "" {
 				t.Errorf("%s\ndecodeAsK8sAPI(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestRequireSchemas(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		req    *fnv1.RunFunctionRequest
+		gvks   []schema.GroupVersionKind
+		want   *fnv1.Requirements
+	}{
+		"WithRequiredSchemasCapability": {
+			reason: "When Crossplane advertises required_schemas, request schemas directly by GVK instead of guessing a CRD name.",
+			req: &fnv1.RunFunctionRequest{
+				Meta: &fnv1.RequestMeta{Capabilities: []fnv1.Capability{fnv1.Capability_CAPABILITY_REQUIRED_SCHEMAS}},
+			},
+			gvks: []schema.GroupVersionKind{{Group: "eks.aws.m.upbound.io", Version: "v1beta1", Kind: "AccessEntry"}},
+			want: &fnv1.Requirements{
+				Schemas: map[string]*fnv1.SchemaSelector{
+					"eks.aws.m.upbound.io/v1beta1, Kind=AccessEntry": {
+						ApiVersion: "eks.aws.m.upbound.io/v1beta1",
+						Kind:       "AccessEntry",
+					},
+				},
+			},
+		},
+		"CRDFallbackUsesCorrectEnglishPlural": {
+			reason: "Without the required_schemas capability, the CRD requested via required_resources must be named with the real English plural (accessentries), not a naive Kind+\"s\" guess (accessentrys) that no CRD in the cluster actually has.",
+			req: &fnv1.RunFunctionRequest{
+				Meta: &fnv1.RequestMeta{Capabilities: []fnv1.Capability{}}, // an older Crossplane version won't advertise capabilities at all
+			},
+			gvks: []schema.GroupVersionKind{{Group: "eks.aws.m.upbound.io", Version: "v1beta1", Kind: "AccessEntry"}},
+			want: &fnv1.Requirements{
+				Resources: map[string]*fnv1.ResourceSelector{
+					"eks.aws.m.upbound.io/v1beta1, Kind=AccessEntry": {
+						ApiVersion: "apiextensions.k8s.io/v1",
+						Kind:       "CustomResourceDefinition",
+						Match:      &fnv1.ResourceSelector_MatchName{MatchName: "accessentries.eks.aws.m.upbound.io"},
+					},
+				},
+			},
+		},
+		"CRDFallbackRegularPlural": {
+			reason: "Kinds with a regular plural still resolve correctly through the fallback path.",
+			req: &fnv1.RunFunctionRequest{
+				Meta: &fnv1.RequestMeta{Capabilities: []fnv1.Capability{}},
+			},
+			gvks: []schema.GroupVersionKind{{Group: "s3.aws.upbound.io", Version: "v1beta1", Kind: "Bucket"}},
+			want: &fnv1.Requirements{
+				Resources: map[string]*fnv1.ResourceSelector{
+					"s3.aws.upbound.io/v1beta1, Kind=Bucket": {
+						ApiVersion: "apiextensions.k8s.io/v1",
+						Kind:       "CustomResourceDefinition",
+						Match:      &fnv1.ResourceSelector_MatchName{MatchName: "buckets.s3.aws.upbound.io"},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			rsp := &fnv1.RunFunctionResponse{Requirements: &fnv1.Requirements{}}
+			requireSchemas(tc.req, rsp, tc.gvks)
+			if diff := cmp.Diff(tc.want, rsp.GetRequirements(), protocmp.Transform()); diff != "" {
+				t.Errorf("%s\nrequireSchemas(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/kong v1.16.0
 	github.com/crossplane/crossplane-runtime/v2 v2.3.3
 	github.com/crossplane/function-sdk-go v0.7.1
+	github.com/gobuffalo/flect v1.0.3
 	github.com/google/cel-go v0.29.2
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
@@ -59,7 +60,6 @@ require (
 	github.com/go-openapi/swag/stringutils v0.26.0 // indirect
 	github.com/go-openapi/swag/typeutils v0.26.0 // indirect
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
-	github.com/gobuffalo/flect v1.0.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 // indirect


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
requireSchemas() guessed the CRD's Kubernetes object name by naively appending "s" to the Kind (e.g. AccessEntry -> accessentrys) when falling back to required_resources on Crossplane/UXP versions that predate the required_schemas capability (< v2.2). Kinds with an irregular English plural (AccessEntry -> AccessEntries, Policy -> Policies, ...) never matched any real CRD, so the resource silently looked "unavailable" and schema resolution for it fell through to the built-in-types-only resolver, producing a misleading "schema not found" error even though the CRD existed and worked fine.

Use flect.Pluralize (already an indirect dependency, the same library Kubernetes codegen tooling uses) to compute the plural instead.

Fixes #116

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
